### PR TITLE
scripts: replace ‘master’ with ‘v$VERSION’ in prerelease script

### DIFF
--- a/scripts/prerelease
+++ b/scripts/prerelease
@@ -3,5 +3,5 @@ set -eufo pipefail
 npm out --long
 npm whoami
 npm run build
-transcribe --heading-level 4 --url 'https://github.com/fluture-js/fluture-sanctuary-types/blob/master/{filename}#L{line}' index.mjs > README.md
+transcribe --heading-level 4 --url "https://github.com/fluture-js/fluture-sanctuary-types/blob/v${VERSION?Environment variable not set}/{filename}#L{line}" index.mjs > README.md
 git add README.md


### PR DESCRIPTION
From the [Transcribe][1] documentation:

> Avoid pointing to a moving target: include a tag name or commit hash rather than a branch name such as `master`.

This change will ensure that code links in future versions of the readme will remain correct forever (assuming that GitHub continues to exist).


[1]: https://github.com/plaid/transcribe
