### PR TITLE
Expand the supported version range of sanctuary-def

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ export var ConcurrentFutureType = $.BinaryType
   (type.parse (Par[$$type]).name)
   ('https://github.com/fluture-js/Fluture#concurrentfuture')
   ([])
-  (function(x) { return type (x) === Par[$$type]; })
+  (function(x) { return type (x) === Par[$$type] && x !== Par; })
   (function(f) { return (seq (f)).extractLeft (); })
   (function(f) { return (seq (f)).extractRight (); });
 

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   "author": "Aldwin Vlasblom <aldwin@avaq.it> (https://github.com/Avaq)",
   "license": "MIT",
   "dependencies": {
-    "sanctuary-type-identifiers": "^2.0.0"
+    "sanctuary-type-identifiers": "^3.0.0"
   },
   "peerDependencies": {
-    "fluture": ">=12.0.0-beta.5 <13.0.0",
-    "sanctuary-def": ">=0.20.0 <0.21.0"
+    "fluture": ">=12.0.0-beta.6 <13.0.0",
+    "sanctuary-def": ">=0.20.0 <0.22.0"
   },
   "devDependencies": {
     "c8": "^7.1.0",
@@ -48,7 +48,7 @@
     "fluture": "^12.2.0",
     "oletus": "^3.0.0",
     "rollup": "^2.0.0",
-    "sanctuary-def": "0.20.1",
+    "sanctuary-def": "^0.21.1",
     "sanctuary-scripts": "^4.0.0",
     "sanctuary-show": "^2.0.0",
     "sanctuary-type-classes": "^12.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import $ from 'sanctuary-def';
 import show from 'sanctuary-show';
 import Z from 'sanctuary-type-classes';
 import type from 'sanctuary-type-identifiers';
-import {Par, resolve} from 'fluture/index.js';
+import {Future, Par, resolve} from 'fluture/index.js';
 import {FutureType, ConcurrentFutureType} from '../index.js';
 import test from 'oletus';
 
@@ -28,6 +28,7 @@ test ('FutureType', () => {
   eq (typeInfo.namespace, 'sanctuary-def');
   eq (typeInfo.name, 'Type');
 
+  eq ($test (Type) (Future), false);
   eq ($test (Type) (Par (resolve (1))), false);
   eq ($test (Type) (resolve (1)), true);
 });
@@ -45,6 +46,7 @@ test ('ConcurrentFutureType', () => {
   eq (typeInfo.namespace, 'sanctuary-def');
   eq (typeInfo.name, 'Type');
 
+  eq ($test (Type) (Par), false);
   eq ($test (Type) (Par (resolve (1))), true);
   eq ($test (Type) (resolve (1)), false);
 });


### PR DESCRIPTION
Sanctuary-Def version 21 updates sanctuary-type-identifiers to
version 3. In order to cooperate with it, we must update
sanctuary-type-identifiers as well.

Fluture only added support for sanctuary-type-identifiers 3 in
12.0.0-beta.6, so as a result of the sanctuary-def version range
expansion, the version range of Fluture must be slightly reduced
from beta 5 at the low edge to beta 6.

That makes this a breaking change.